### PR TITLE
All parks endpoint

### DIFF
--- a/app/controllers/api/v1/parks_controller.rb
+++ b/app/controllers/api/v1/parks_controller.rb
@@ -1,6 +1,22 @@
 class Api::V1::ParksController < ApplicationController
   def index
-    location = search_params[:location].downcase.squish
+    if search_params[:location].nil?
+      parks = Park.all
+      render json: ParkSerializer.new(parks).serialized_json
+    else
+      park = search_for_park(search_params[:location])
+      render json: ParkSerializer.new(park).serialized_json
+    end
+  end
+
+  private
+
+  def search_params
+    params.permit(:location)
+  end
+
+  def search_for_park(search_location)
+    location = search_location.downcase.squish
     search = Search.find_by(location: location)
     if search
       park = search.parks.first
@@ -8,12 +24,6 @@ class Api::V1::ParksController < ApplicationController
       park = ParkFacade.by_location(location)
       park.searches << Search.create(location: location)
     end
-    render json: ParkSerializer.new(park).serialized_json
-  end
-
-  private
-
-  def search_params
-    params.permit(:location)
+    park
   end
 end

--- a/app/services/image_service.rb
+++ b/app/services/image_service.rb
@@ -2,8 +2,12 @@ class ImageService
   def self.get_by_name(name)
   response = get_json(name)
   parsed = JSON.parse(response.body, symbolize_names: true)
-  num = rand(0..parsed[:hits].size-1)
-  parsed[:hits][num][:largeImageURL]
+  if parsed[:total] == 0
+    'https://www.nps.gov/aboutus/news/images/JOTR_NPSBradSutton_960w.jpg'
+  else
+    num = rand(0..parsed[:hits].size-1)
+    parsed[:hits][num][:largeImageURL]
+  end
 end
 
 private

--- a/spec/requests/api/v1/parks/get_all_parks_spec.rb
+++ b/spec/requests/api/v1/parks/get_all_parks_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'Get all parks by parks Endpoint' do
+  it 'can receive a location and return park data' do
+    get "/api/v1/parks?location=denver,co"
+    get "/api/v1/parks?location=washington,dc"
+    get "/api/v1/parks?location=seattle,wa"
+
+    expect(Search.count).to eq(3)
+    expect(Park.count).to eq(3)
+
+    get '/api/v1/parks'
+
+    expect(response).to be_successful
+    expect(response.content_type).to eq('application/json')
+
+    data = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    expect(data.size).to eq(3)
+
+    data.each do |park|
+      expect(park[:type]).to eq('park')
+      expect(park[:attributes].keys).to include(:name)
+      expect(park[:attributes].keys).to include(:description)
+      expect(park[:attributes].keys).to include(:directions)
+      expect(park[:attributes].keys).to include(:image_url)
+    end
+  end
+end

--- a/spec/requests/api/v1/parks/search_park_spec.rb
+++ b/spec/requests/api/v1/parks/search_park_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Get Park by Search Endpoint' do
+RSpec.describe 'Search Park by parks  Endpoint' do
   it 'can receive a location and return park data' do
     location = 'denver,co'
     get "/api/v1/parks?location=#{location}"


### PR DESCRIPTION
# Description
Adds new functionality to parks endpoint. If there are no search parameters, it will return all previous searched parks
Adds sad path with generic image for image service failure

# Closes issue(s)
closes #6 

# How to test / reproduce
`$ bundle exec rspec`


# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [X] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [X] I have tested this code
- [X] I have updated the Readme

# Other comments
